### PR TITLE
If you run the script twice, don't follow all the accounts you just unblocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,3 @@ Once the script can no longer scroll, it finds all of the unblock buttons, by se
  * Click Ok/Yes to unblock every account
  * Click Cancel/No to do nothing
 1. Refresh the page to verify that accounts have been unblocked
-
-# Issues
-* If you **accidentally run the unblock script twice** (via either `main()` or `unblock(...)`) **without reloading**, you will follow everyone you just unblocked. 
-
- *If this occurs*:
-  * **DO NOT RELOAD THE PAGE**
-  * Run the script again
-  * Press Ok/Yes to "unblock" every account. The button clicked by the script remains the same, but will instead unfollow the accounts.

--- a/unblock.js
+++ b/unblock.js
@@ -6,8 +6,10 @@ function clickAll(buttons) {
         var button = buttons[i];
 
         // If somebody runs the script twice, we don't want to follow
-        // the account they've just unblocked.  We'll mark each button
-        // with an attribute to avoid clicking it twice.
+        // the account they've just unblocked by re-clicking the buttons.
+        //
+        // We'll mark each button with an attribute so we know what we've
+        // already clicked.
         var trackingAttribute = "hasBeenClickedByUnblockAll";
         if (button.getAttribute(trackingAttribute) === null) {
             button.click();

--- a/unblock.js
+++ b/unblock.js
@@ -8,9 +8,10 @@ function clickAll(buttons) {
         // If somebody runs the script twice, we don't want to follow
         // the account they've just unblocked.  We'll mark each button
         // with an attribute to avoid clicking it twice.
-        if (typeof button.hasBeenClickedByUnblockAll == "undefined") {
+        var trackingAttribute = "hasBeenClickedByUnblockAll";
+        if (button.getAttribute(trackingAttribute) === null) {
             button.click();
-            button.hasBeenClickedByUnblockAll = true;
+            button.setAttribute(trackingAttribute, true);
         }
     }
 }

--- a/unblock.js
+++ b/unblock.js
@@ -3,7 +3,15 @@ function sleep(ms) {
 }
 function clickAll(buttons) {
     for (i = 0; i < buttons.length; i++) {
-        buttons[i].click();
+        var button = buttons[i];
+
+        // If somebody runs the script twice, we don't want to follow
+        // the account they've just unblocked.  We'll mark each button
+        // with an attribute to avoid clicking it twice.
+        if (typeof button.hasBeenClickedByUnblockAll == "undefined") {
+            button.click();
+            button.hasBeenClickedByUnblockAll = true;
+        }
     }
 }
 async function unblock(timeoutMs, maxScrolls) {


### PR DESCRIPTION
This is both annoying and potentially dangerous – if a user follows a bunch of people who were previously blocked, it:

1. Alerts those people that they're no longer blocked
2. Flags the user to those people, potentially making them a target for harassment or abuse

This modifies the script not to click the button if it’s already been clicked at least once – avoiding this failure mode.

### Testing

1. I created a fresh Twitter account and blocked two accounts.
2. I followed the steps in the README, using the original code, and called `main()` twice – and confirmed I saw the original bug.
3. I reblocked the two accounts.
4. I ran the new version of the script. I called `main()` once, and both accounts were unblocked. I called `main()` a second time, and confirmed I hadn’t started following those two users.